### PR TITLE
Fix console error in Swap Accounts when user menu is missing

### DIFF
--- a/features/swap-accounts.js
+++ b/features/swap-accounts.js
@@ -102,6 +102,10 @@ const swapIconSvg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
             parentContainer.insertBefore(swapButton, userMenu);
 
         } catch (error) {
+            if (error.message && (error.message.includes('not found') || error.message.includes('timeout'))) {
+                console.debug('Swap Accounts: User menu not found, skipping.');
+                return;
+            }
             console.error('Could not add Switch Accounts button:', error);
         }
     }


### PR DESCRIPTION
The `addSwapAccountsButton` function was throwing an unhandled error when the user menu element was not found on the page (e.g. on pages where it is not expected).

This change adds a check in the `catch` block to suppress the error if it is due to the element not being found or timing out, logging a debug message instead. Unexpected errors are still logged as errors.